### PR TITLE
Update pUZI-php dependency to ^0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.3",
-        "minvws/puzi-php": "^0.4",
+        "minvws/puzi-php": "^0.5",
         "laravel/framework": "^6.0|^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
This allows for use of more segregated exceptions.