### PR TITLE
Get certificate between start and end lines

### DIFF
--- a/src/UziServiceProvider.php
+++ b/src/UziServiceProvider.php
@@ -17,48 +17,56 @@ class UziServiceProvider extends ServiceProvider
      * Boots the Service provider.
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->publishes([
             __DIR__ . '/config/uzi.php' => config_path('uzi.php')
         ]);
     }
 
-    public function register()
+    public function register(): void
     {
         $this->app->bind(UziValidator::class, function () {
-
-            // Split certificates from file
-            $caCerts = [];
-            $path = config('uzi.ca_certs_path', null);
-            if ($path) {
-                $fileContent = @file_get_contents($path);
-                if ($fileContent === false) {
-                    throw new \RuntimeException("Could not read CA certificates from $path");
-                }
-
-                $caCerts = preg_split('/-----BEGIN CERTIFICATE-----/', $fileContent);
-                if ($caCerts === false) {
-                    $caCerts = [];
-                } else {
-                    // remove empty first element
-                    array_shift($caCerts);
-                }
-
-                foreach ($caCerts as &$cert) {
-                    $cert = trim($cert);
-                    $cert = str_replace('-----END CERTIFICATE-----', '', $cert);
-                    $cert = str_replace("\n", '', $cert);
-                }
-            }
-
             return new UziValidator(
                 new UziReader(),
                 config("uzi.strict_ca_check", true),
                 config("uzi.allowed_types", []),
                 config("uzi.allowed_roles", []),
-                $caCerts
+                $this->getCACerts(config("uzi.ca_cert_path")),
             );
         });
+    }
+
+    /**
+     * Get the CA certificates from the given path
+     * @param ?string $path
+     * @return array
+     */
+    public function getCACerts(?string $path): array
+    {
+        if (empty($path)) {
+            return [];
+        }
+
+        $fileContent = @file_get_contents($path);
+        if ($fileContent === false) {
+            throw new \RuntimeException("Could not read CA certificates from $path");
+        }
+
+        $caCerts = preg_split('/-----BEGIN CERTIFICATE-----/', $fileContent);
+        if ($caCerts === false) {
+            return [];
+        }
+
+        // remove empty first element
+        array_shift($caCerts);
+
+        foreach ($caCerts as &$cert) {
+            $cert = trim($cert);
+            $cert = substr($cert, 0, strpos($cert, '-----END CERTIFICATE-----') ?: 0);
+            $cert = str_replace("\n", '', $cert);
+        }
+
+        return $caCerts;
     }
 }

--- a/tests/Resources/test-fake-ca-file.pem
+++ b/tests/Resources/test-fake-ca-file.pem
@@ -1,0 +1,12 @@
+# subject=Some subject
+# issuer=Some issuer
+# notAfter=Some data
+-----BEGIN CERTIFICATE-----
+Some certificate data....
+-----END CERTIFICATE-----
+# subject=Some subject
+# issuer=Some issuer
+# notAfter=Some data
+-----BEGIN CERTIFICATE-----
+Some other certificate data....
+-----END CERTIFICATE-----

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace MinVWS\PUZI\Laravel\Tests;
+
+use MinVWS\PUZI\Laravel\UziServiceProvider;
+
+class TestCase extends \Orchestra\Testbench\TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        // additional setup
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            UziServiceProvider::class,
+        ];
+    }
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        // perform environment setup
+    }
+}

--- a/tests/UziServiceProviderTest.php
+++ b/tests/UziServiceProviderTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace MinVWS\PUZI\Laravel\Tests;
+
+use Illuminate\Support\Facades\App;
+use MinVWS\PUZI\Laravel\UziServiceProvider;
+
+class UziServiceProviderTest extends TestCase
+{
+    public function testCACertsEmpty(): void
+    {
+        $serviceProvider = new UziServiceProvider(app());
+
+        $this->assertEmpty($serviceProvider->getCACerts(null));
+        $this->assertEmpty($serviceProvider->getCACerts(''));
+    }
+
+    public function testCACerts(): void
+    {
+        $serviceProvider = new UziServiceProvider(app());
+
+        $caCerts = $serviceProvider->getCACerts(__DIR__ . '/Resources/test-fake-ca-file.pem');
+
+        $this->assertCount(2, $caCerts);
+        $this->assertSame([
+            'Some certificate data....',
+            'Some other certificate data....',
+        ], $caCerts);
+    }
+}


### PR DESCRIPTION
Instead of replacing the `-----END CERTIFICATE-----` part, we will only load the data between the start and end lines.